### PR TITLE
fix: Internal Sanic websocket import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ xmltodict
 dicttoxml
 pycryptodome
 httpx==0.20.0
+websockets>=10.0,<11.0
 sanic==21.12.1


### PR DESCRIPTION
This PR fixes an issue with Sanic crashing when importing from `websockets.connection`.
This is a temporary fix until Sanic fixes their constraints.

### Steps I did to reproduce

1. Clone repo
2. Try to deploy using docker
3. Observe crash in application output

### Stack Trace
```
ImportError: cannot import name 'CLOSED' from 'websockets.connection' (/usr/local/lib/python3.9/site-packages/websockets/connection.py)
Traceback (most recent call last):
  File "/usr/local/bin/sanic", line 5, in <module>
    from sanic.__main__ import main
  File "/usr/local/lib/python3.9/site-packages/sanic/__init__.py", line 2, in <module>
    from sanic.app import Sanic
  File "/usr/local/lib/python3.9/site-packages/sanic/app.py", line 102, in <module>
    from sanic.server.protocols.websocket_protocol import WebSocketProtocol
  File "/usr/local/lib/python3.9/site-packages/sanic/server/protocols/websocket_protocol.py", line 3, in <module>
    from websockets.connection import CLOSED, CLOSING, OPEN
samfetch-samfetch-1  | ImportError: cannot import name 'CLOSED' from 'websockets.connection' (/usr/local/lib/python3.9/site-packages/websockets/connection.py)
```

### Related
https://github.com/sanic-org/sanic/issues/2733